### PR TITLE
fix for ubuntu/mysql client connection issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
          - ./data/mongodb:/data/db
       restart: always
    mysql:
-      image: mysql
+      image: mysql:5.7
       expose:
          - 3306
       environment:


### PR DESCRIPTION
Limited MySQL version to prevent known error:

```
ERROR 2059 (HY000): Authentication plugin 'caching_sha2_password' cannot be loaded:
/usr/lib64/mysql/plugin/caching_sha2_password.so: cannot open shared object file: No such file or directory
```