### PR TITLE
Changed the regex to match the naming of functions of radare2

### DIFF
--- a/server/rest/views.py
+++ b/server/rest/views.py
@@ -191,11 +191,11 @@ def metadata_add(request, md5_hash, crc32, user):
                                         'Report issue is this is a valid '
                                         'API').format(api)})
 
-            if not re.match('^[a-zA-Z\d_:@\?\$]+$', api):
+            if not re.match('^[a-zA-Z\d_:@\?\$i\.]+$', api):
                 return render(request, 'rest/error_json.html',
                                 {'msg' : ('Invalid characters in API, supported'
                                         'characters match the regex /^[a-zA-Z'
-                                        '\\d_:@\\?\\$]+$/. Report issue if'
+                                        '\\d_:@\\?\\$\\.]+$/. Report issue if'
                                         'the submitted API valid is valid.')})
 
     #   All input has been validated
@@ -498,11 +498,11 @@ def metadata_scan(request, user):
                                         'Report issue is this is a valid '
                                         'API').format(api)})
 
-            if not re.match('^[a-zA-Z\d_:@\?\$]+$', api):
+            if not re.match('^[a-zA-Z\d_:@\?\$\.]+$', api):
                 return render(request, 'rest/error_json.html',
                                 {'msg' : ('Invalid characters in API, supported'
                                         'characters match the regex /^[a-zA-Z'
-                                        '\\d_:@\\?\\$]+$/. Report issue if'
+                                        '\\d_:@\\?\\$\\.]+$/. Report issue if'
                                         'the submitted API valid is valid.')})
 
         try:


### PR DESCRIPTION
I built a radare2 plugin that integrates with FIRST server. These changes are necessary to make the server able to accept add and scan REST requests coming from the radare2 plugin.
This is because radare2 function names include "."